### PR TITLE
feat(auth): user registration, login and admin-only book management 

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -44,6 +44,14 @@
 			<artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>

--- a/backend/src/main/java/com/biblio/backend/BackendApplication.java
+++ b/backend/src/main/java/com/biblio/backend/BackendApplication.java
@@ -2,12 +2,16 @@ package com.biblio.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 @SpringBootApplication
 public class BackendApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(BackendApplication.class, args);
+        //BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+        //String hash1 = encoder.encode("...");
+        //System.out.println(hash1);
 	}
 
 	/*@Bean

--- a/backend/src/main/java/com/biblio/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/biblio/backend/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import static org.springframework.security.config.Customizer.withDefaults;
 
 @Configuration
 @EnableWebSecurity
@@ -19,17 +20,18 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 // Routes publiques
                 .requestMatchers("/api/auth/**").permitAll()
-                .requestMatchers(HttpMethod.GET, "/api/books/**").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/books").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/books/{id}").permitAll()
 
-                // Seul admin peut supprimer, modifier, créer un livre
-                .requestMatchers(HttpMethod.DELETE, "/api/books/**").hasAuthority("ROLE_ADMIN")
-                .requestMatchers(HttpMethod.PUT, "/api/books/**").hasRole("ADMIN")
+                // ADMIN seulement (tout en hasRole pour uniformité)
                 .requestMatchers(HttpMethod.POST, "/api/books").hasRole("ADMIN")
+                .requestMatchers(HttpMethod.PUT, "/api/books/**").hasRole("ADMIN")
+                .requestMatchers(HttpMethod.DELETE, "/api/books/**").hasRole("ADMIN")  // ← CHANGE ÇA !
                 
                 // Tout le reste nécessite d'être authentifié
                 .anyRequest().authenticated()
             )
-            .httpBasic();
+            .httpBasic(withDefaults());
 
         return http.build();
     }

--- a/backend/src/main/java/com/biblio/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/biblio/backend/config/SecurityConfig.java
@@ -21,9 +21,11 @@ public class SecurityConfig {
                 .requestMatchers("/api/auth/**").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/books/**").permitAll()
 
-                // Seul admin peut supprimer
+                // Seul admin peut supprimer, modifier, créer un livre
                 .requestMatchers(HttpMethod.DELETE, "/api/books/**").hasAuthority("ROLE_ADMIN")
-
+                .requestMatchers(HttpMethod.PUT, "/api/books/**").hasRole("ADMIN")
+                .requestMatchers(HttpMethod.POST, "/api/books").hasRole("ADMIN")
+                
                 // Tout le reste nécessite d'être authentifié
                 .anyRequest().authenticated()
             )

--- a/backend/src/main/java/com/biblio/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/biblio/backend/config/SecurityConfig.java
@@ -1,0 +1,39 @@
+package com.biblio.backend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth
+                // Routes publiques
+                .requestMatchers("/api/auth/**").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/books/**").permitAll()
+
+                // Seul admin peut supprimer
+                .requestMatchers(HttpMethod.DELETE, "/api/books/**").hasAuthority("ROLE_ADMIN")
+
+                // Tout le reste nécessite d'être authentifié
+                .anyRequest().authenticated()
+            )
+            .httpBasic();
+
+        return http.build();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/backend/src/main/java/com/biblio/backend/controller/UserController.java
+++ b/backend/src/main/java/com/biblio/backend/controller/UserController.java
@@ -3,11 +3,13 @@ package com.biblio.backend.controller;
 import com.biblio.backend.dto.LoginRequest;
 import com.biblio.backend.dto.RegisterRequest;
 import com.biblio.backend.model.User;
+import com.biblio.backend.repository.UserRepository;
 import com.biblio.backend.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
@@ -19,17 +21,19 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
+    private final UserRepository userRepository;
 
     @PostMapping("/login")
-    public ResponseEntity<User> login(@RequestBody LoginRequest request) {
+    public ResponseEntity<Map<String, Object>> login(@RequestBody LoginRequest request) {
         User user = userService.login(request.getUsername(), request.getPassword());
 
-        /* Map<String, Object> response = new HashMap<>();
+        //Customiser la réponse pr ne pas afficher le mdp
+        Map<String, Object> response = new HashMap<>();
         response.put("message", "Connexion réussie");
         response.put("username", user.getUsername());
-        response.put("userId", user.getId()); */ 
+        response.put("userId", user.getId()); 
 
-        return ResponseEntity.ok(user); //on retourne l'entité 
+        return ResponseEntity.ok(response); //on retourne la réponse 
     }
 
    @PostMapping("/register")
@@ -49,4 +53,9 @@ public class UserController {
     return ResponseEntity.ok(response);
 
 }
+
+    @GetMapping("/users")
+    public List<User> getAllUsers() {
+        return userRepository.findAll();
+    }
 }

--- a/backend/src/main/java/com/biblio/backend/controller/UserController.java
+++ b/backend/src/main/java/com/biblio/backend/controller/UserController.java
@@ -1,0 +1,52 @@
+package com.biblio.backend.controller;
+
+import com.biblio.backend.dto.LoginRequest;
+import com.biblio.backend.dto.RegisterRequest;
+import com.biblio.backend.model.User;
+import com.biblio.backend.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/login")
+    public ResponseEntity<User> login(@RequestBody LoginRequest request) {
+        User user = userService.login(request.getUsername(), request.getPassword());
+
+        /* Map<String, Object> response = new HashMap<>();
+        response.put("message", "Connexion réussie");
+        response.put("username", user.getUsername());
+        response.put("userId", user.getId()); */ 
+
+        return ResponseEntity.ok(user); //on retourne l'entité 
+    }
+
+   @PostMapping("/register")
+    public ResponseEntity<Map<String, Object>> register(@Valid @RequestBody RegisterRequest request) {
+    // Si @Valid échoue → GlobalExceptionHandler s'en occupe
+    // Si service lance exception → erreur 500 pour l'instant
+
+    User user = userService.register(request);
+
+    //Customiser la réponse JSON (pour ne pas afficher le mot de passe)
+    Map<String, Object> response = new HashMap<>();
+    response.put("message", "Compte créé avec succès");
+    response.put("username", user.getUsername());  
+    response.put("userId", user.getId());          
+    
+    // Retourne HTTP 200 OK avec le JSON
+    return ResponseEntity.ok(response);
+
+}
+}

--- a/backend/src/main/java/com/biblio/backend/dto/LoginRequest.java
+++ b/backend/src/main/java/com/biblio/backend/dto/LoginRequest.java
@@ -1,9 +1,12 @@
 package com.biblio.backend.dto;
 
-import lombok.Data;
-
-@Data
 public class LoginRequest {
     private String username;
     private String password;
+    
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+    
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
 }

--- a/backend/src/main/java/com/biblio/backend/dto/LoginRequest.java
+++ b/backend/src/main/java/com/biblio/backend/dto/LoginRequest.java
@@ -1,0 +1,9 @@
+package com.biblio.backend.dto;
+
+import lombok.Data;
+
+@Data
+public class LoginRequest {
+    private String username;
+    private String password;
+}

--- a/backend/src/main/java/com/biblio/backend/dto/RegisterRequest.java
+++ b/backend/src/main/java/com/biblio/backend/dto/RegisterRequest.java
@@ -1,0 +1,29 @@
+package com.biblio.backend.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class RegisterRequest {
+    
+    @NotBlank(message = "Username requis")
+    @Size(min = 3, message = "Username trop court")
+    private String username;
+    
+    @NotBlank(message = "Email requis")
+    @Email(message = "Email invalide")
+    private String email;
+    
+    @NotBlank(message = "Mot de passe requis")
+    @Size(min = 6, message = "Mot de passe trop court")
+    private String password;
+    
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+    
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+}

--- a/backend/src/main/java/com/biblio/backend/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/biblio/backend/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.biblio.backend.exception;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -12,6 +13,7 @@ import java.util.Map;
 @ControllerAdvice
 public class GlobalExceptionHandler {
     
+    // 1. Erreurs de validation (@Valid dans controller)
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Map<String, String>> handleValidationExceptions(
             MethodArgumentNotValidException ex) {
@@ -22,6 +24,27 @@ public class GlobalExceptionHandler {
             String errorMessage = error.getDefaultMessage();
             errors.put(fieldName, errorMessage);
         });
-        return ResponseEntity.badRequest().body(errors);
+        return ResponseEntity.badRequest().body(errors); // HTTP 400
+    }
+    
+    // 2. erreurs métier de UserService
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<Map<String, String>> handleBusinessExceptions(
+            RuntimeException ex) {
+        
+        Map<String, String> error = new HashMap<>();
+        String message = ex.getMessage();
+        error.put("error", message);
+        
+        // Donne le bon HTTP status selon le message
+        if (message.contains("Mot de passe incorrect")) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(error); // 401
+        } else if (message.contains("Utilisateur non trouvé")) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error); // 404
+        } else if (message.contains("déjà pris") || message.contains("déjà utilisé")) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(error); // 409
+        } else {
+            return ResponseEntity.badRequest().body(error); // 400 par défaut
+        }
     }
 }

--- a/backend/src/main/java/com/biblio/backend/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/biblio/backend/exception/GlobalExceptionHandler.java
@@ -1,0 +1,27 @@
+package com.biblio.backend.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+    
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidationExceptions(
+            MethodArgumentNotValidException ex) {
+        
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getAllErrors().forEach((error) -> {
+            String fieldName = ((FieldError) error).getField();
+            String errorMessage = error.getDefaultMessage();
+            errors.put(fieldName, errorMessage);
+        });
+        return ResponseEntity.badRequest().body(errors);
+    }
+}

--- a/backend/src/main/java/com/biblio/backend/model/User.java
+++ b/backend/src/main/java/com/biblio/backend/model/User.java
@@ -1,0 +1,49 @@
+package com.biblio.backend.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "users")
+public class User {
+    
+    @Id 
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(unique = true, nullable = false)
+    private String username;
+    
+    @Column(unique = true, nullable = false)
+    private String email;
+    
+    @Column(nullable = false)
+    private String password;
+    
+    @Column(name = "is_admin") 
+    private boolean admin = false;
+    
+    public User() {}
+    
+    public User(Long id, String username, String email, String password, boolean admin) {
+        this.id = id;
+        this.username = username;
+        this.email = email;
+        this.password = password;
+        this.admin = admin;
+    }
+    
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+    
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+    
+    public boolean isAdmin() { return admin; }
+    public void setAdmin(boolean admin) { this.admin = admin; }
+}

--- a/backend/src/main/java/com/biblio/backend/model/User.java
+++ b/backend/src/main/java/com/biblio/backend/model/User.java
@@ -2,10 +2,17 @@ package com.biblio.backend.model;
 
 import jakarta.persistence.*;
 
+import java.util.Collection;
+import java.util.List;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
 @Entity
 @Table(name = "users")
-public class User {
-    
+public class User implements UserDetails  { // Spring Security dit : "Montre-moi à quoi ressemble un user". UserDetails = contrat obligatoire
+
     @Id 
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -46,4 +53,27 @@ public class User {
     
     public boolean isAdmin() { return admin; }
     public void setAdmin(boolean admin) { this.admin = admin; }
+
+
+     @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() { //Quels pouvoirs a cet user ?
+        // Si admin = true → ROLE_ADMIN, sinon ROLE_USER
+        String role = admin ? "ROLE_ADMIN" : "ROLE_USER";
+        return List.of(new SimpleGrantedAuthority(role));
+    }
+
+    //Le compte n'a pas expiré
+    @Override
+    public boolean isAccountNonExpired() { return true; }
+    
+    //Le compte n'est pas bloqué
+    @Override
+    public boolean isAccountNonLocked() { return true; }
+    
+    //Le mdp n'a pas expiré
+    @Override
+    public boolean isCredentialsNonExpired() { return true; }
+    
+    @Override
+    public boolean isEnabled() { return true; }
 }

--- a/backend/src/main/java/com/biblio/backend/repository/UserRepository.java
+++ b/backend/src/main/java/com/biblio/backend/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.biblio.backend.repository;
+
+import com.biblio.backend.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+    boolean existsByUsername(String username);
+    boolean existsByEmail(String email);
+}

--- a/backend/src/main/java/com/biblio/backend/service/UserDetailsServiceImpl.java
+++ b/backend/src/main/java/com/biblio/backend/service/UserDetailsServiceImpl.java
@@ -1,0 +1,24 @@
+package com.biblio.backend.service;
+
+import com.biblio.backend.model.User;
+import com.biblio.backend.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserDetailsServiceImpl implements UserDetailsService { //Si on veut que Spring security charge les users depuis la db
+    
+    @Autowired
+    private UserRepository userRepository;
+    
+    //Spring Security demande : "Quand j'ai un username, comment je le trouve dans TA base ?", je réponds : "Cherche dans ma table users avec findByUsername()"
+    @Override
+    public UserDetails loadUserByUsername(String username) {
+        User user = userRepository.findByUsername(username)
+            .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+        return user;  // User implémente déjà UserDetails
+    }
+}

--- a/backend/src/main/java/com/biblio/backend/service/UserService.java
+++ b/backend/src/main/java/com/biblio/backend/service/UserService.java
@@ -1,0 +1,47 @@
+package com.biblio.backend.service;
+
+import com.biblio.backend.dto.RegisterRequest;
+import com.biblio.backend.model.User;
+import com.biblio.backend.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+    public User register(RegisterRequest request) {
+        if (userRepository.existsByUsername(request.getUsername())) {
+            throw new RuntimeException("Username déjà pris");
+        }
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new RuntimeException("Email déjà utilisé");
+        }
+
+        User user = new User();
+        user.setUsername(request.getUsername());
+        user.setEmail(request.getEmail());
+        user.setPassword(passwordEncoder.encode(request.getPassword()));
+        user.setAdmin(false);
+
+        return userRepository.save(user);
+    }
+
+    public User login(String username, String password) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new RuntimeException("Utilisateur non trouvé"));
+
+        if (!passwordEncoder.matches(password, user.getPassword())) {
+            throw new RuntimeException("Mot de passe incorrect");
+        }
+        return user;
+    }
+
+    public boolean isAdmin(User user) {
+        return user != null && user.isAdmin();
+    }
+}

--- a/backend/src/main/java/com/biblio/backend/service/UserService.java
+++ b/backend/src/main/java/com/biblio/backend/service/UserService.java
@@ -3,17 +3,18 @@ package com.biblio.backend.service;
 import com.biblio.backend.dto.RegisterRequest;
 import com.biblio.backend.model.User;
 import com.biblio.backend.repository.UserRepository;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
-@RequiredArgsConstructor
 public class UserService {
-
-    private final UserRepository userRepository;
+    
+    @Autowired
+    private UserRepository userRepository;
+    
     private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
-
+    
     public User register(RegisterRequest request) {
         if (userRepository.existsByUsername(request.getUsername())) {
             throw new RuntimeException("Username déjà pris");
@@ -21,26 +22,26 @@ public class UserService {
         if (userRepository.existsByEmail(request.getEmail())) {
             throw new RuntimeException("Email déjà utilisé");
         }
-
+        
         User user = new User();
         user.setUsername(request.getUsername());
         user.setEmail(request.getEmail());
         user.setPassword(passwordEncoder.encode(request.getPassword()));
         user.setAdmin(false);
-
+        
         return userRepository.save(user);
     }
-
+    
     public User login(String username, String password) {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new RuntimeException("Utilisateur non trouvé"));
-
+        
         if (!passwordEncoder.matches(password, user.getPassword())) {
             throw new RuntimeException("Mot de passe incorrect");
         }
         return user;
     }
-
+    
     public boolean isAdmin(User user) {
         return user != null && user.isAdmin();
     }

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -5,11 +5,13 @@ VALUES
 ('978-0-452-28423-4', '1984', 'George Orwell', 'Dystopie', 'Dans un monde totalitaire...', 'https://m.media-amazon.com/images/I/71kxa1-0mfL.jpg', 2)
 ON CONFLICT (isbn) DO NOTHING;  
 
+-- Supprime et réinsère pour être sûr
+DELETE FROM users WHERE username = 'admin';
+
 INSERT INTO users (username, email, password, is_admin) 
 VALUES (
     'admin', 
     'admin@biblio.fr', 
-    '$2a$10$X5eXfB0qBwQ6NqQ8Q2Q3QeY5eXfB0qBwQ6NqQ8Q2Q3QeY5eXfB0qBwQ6NqQ8',  
+    '$2a$10$R0Vhlt/dafe.IslLByhNfunQzLgcmH154mTcUPocEgn9PnOMi9giq',  
     true
-)
-ON CONFLICT (username) DO NOTHING;  
+);

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -4,3 +4,12 @@ VALUES
 ('978-2-266-15410-3', 'Le Seigneur des Anneaux', 'J.R.R. Tolkien', 'Fantasy', 'L''histoire de Frodon et de l''Anneau unique...', 'https://m.media-amazon.com/images/I/91jBdaRVqML.jpg', 3),
 ('978-0-452-28423-4', '1984', 'George Orwell', 'Dystopie', 'Dans un monde totalitaire...', 'https://m.media-amazon.com/images/I/71kxa1-0mfL.jpg', 2)
 ON CONFLICT (isbn) DO NOTHING;  
+
+INSERT INTO users (username, email, password, is_admin) 
+VALUES (
+    'admin', 
+    'admin@biblio.fr', 
+    '$2a$10$X5eXfB0qBwQ6NqQ8Q2Q3QeY5eXfB0qBwQ6NqQ8Q2Q3QeY5eXfB0qBwQ6NqQ8',  
+    true
+)
+ON CONFLICT (username) DO NOTHING;  

--- a/backend/src/test/java/com/biblio/backend/controller/BookControllerTest.java
+++ b/backend/src/test/java/com/biblio/backend/controller/BookControllerTest.java
@@ -5,6 +5,7 @@ import com.biblio.backend.service.BookService;
 import java.util.ArrayList;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -19,6 +20,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 
 @WebMvcTest(BookController.class) 
+@AutoConfigureMockMvc(addFilters = false)  // désactive les filtres Spring Security
 public class BookControllerTest {
 
     @Autowired


### PR DESCRIPTION
Implement complete user authentication & authorization with Spring Security

- User registration (`POST /api/auth/register`)
- User login (`POST /api/auth/login`)
- Passwords hashed with BCrypt
- User entity implements `UserDetails` with roles:
  - `ROLE_ADMIN` if `isAdmin = true`
  - `ROLE_USER` otherwise
- `UserDetailsServiceImpl` loads users from database
- Full `SecurityConfig`:
  - `/api/auth/**` and `GET /api/books/**` → public
  - `POST / PUT / DELETE /api/books/**` → **admin only** (`ROLE_ADMIN`)
  - All other endpoints → require authentication

Closes #10